### PR TITLE
Fixed bug in removeAllFiles

### DIFF
--- a/src/components/VueTransmit.vue
+++ b/src/components/VueTransmit.vue
@@ -584,17 +584,13 @@ export default Vue.extend({
 			this.getFilesWithStatus(...statuses).map(this.removeFile);
 		},
 		removeAllFiles(cancelInProgressUploads = false): void {
-			let f: VTransmitFile;
-			let filesToRemove: VTransmitFile[] = [];
-			for (f of this.files) {
-				if (
-					f.status !== UploadStatuses.Uploading ||
-					cancelInProgressUploads
-				) {
-					filesToRemove.push(f);
-				}
+			let filesToRemove: VTransmitFile[] = this.files;
+			if (!cancelInProgressUploads) {
+				filesToRemove = filesToRemove.filter(
+					f => f.status !== UploadStatuses.Uploading
+				);
 			}
-			filesToRemove.map(f => this.removeFile(f));
+			filesToRemove.map(this.removeFile);
 		},
 		triggerBrowseFiles(): void {
 			if (this.inputEl) {

--- a/src/components/VueTransmit.vue
+++ b/src/components/VueTransmit.vue
@@ -584,13 +584,13 @@ export default Vue.extend({
 			this.getFilesWithStatus(...statuses).map(this.removeFile);
 		},
 		removeAllFiles(cancelInProgressUploads = false): void {
-			let filesToRemove: VTransmitFile[] = this.files;
-			if (!cancelInProgressUploads) {
-				filesToRemove = filesToRemove.filter(
-					f => f.status !== UploadStatuses.Uploading
-				);
-			}
-			filesToRemove.map(this.removeFile);
+			this.files
+				.filter(
+					f =>
+						f.status !== UploadStatuses.Uploading ||
+						cancelInProgressUploads
+				)
+				.map(this.removeFile);
 		},
 		triggerBrowseFiles(): void {
 			if (this.inputEl) {

--- a/src/components/VueTransmit.vue
+++ b/src/components/VueTransmit.vue
@@ -585,14 +585,16 @@ export default Vue.extend({
 		},
 		removeAllFiles(cancelInProgressUploads = false): void {
 			let f: VTransmitFile;
+			let filesToRemove: VTransmitFile[] = [];
 			for (f of this.files) {
 				if (
 					f.status !== UploadStatuses.Uploading ||
 					cancelInProgressUploads
 				) {
-					this.removeFile(f);
+					filesToRemove.push(f);
 				}
 			}
+			filesToRemove.map(f => this.removeFile(f));
 		},
 		triggerBrowseFiles(): void {
 			if (this.inputEl) {


### PR DESCRIPTION
Not all files were being removed. This was caused
by the 'files' array being modified during the
call to removeFile.