### PR TITLE
Fixed bug in removeAllFiles (for 8.x)

### DIFF
--- a/src/components/VueTransmit.vue
+++ b/src/components/VueTransmit.vue
@@ -436,11 +436,7 @@ export default class VueTransmit extends Vue {
     this.getFilesWithStatus(...statuses).map(this.removeFile);
   }
   removeAllFiles(cancelInProgressUploads = false): void {
-    for (const file of this.files) {
-      if (file.status !== STATUSES.UPLOADING || cancelInProgressUploads) {
-        this.removeFile(file);
-      }
-    }
+    this.files.filter(f => f.status !== STATUSES.UPLOADING || cancelInProgressUploads).map(this.removeFile);
   }
   triggerBrowseFiles(): void {
     this.inputEl.click();


### PR DESCRIPTION
Not all files were being removed. This was caused
by the 'files' array being modified during the
call to removeFile.